### PR TITLE
Prevent attempting to create custom_permalink for non-public post type

### DIFF
--- a/frontend/class-custom-permalinks-form.php
+++ b/frontend/class-custom-permalinks-form.php
@@ -138,7 +138,7 @@ class Custom_Permalinks_Form
      */
     public function save_post( $post_id )
     {
-        if ( ! isset( $_REQUEST['custom_permalinks_edit'] ) ) {
+        if ( ! isset( $_REQUEST['custom_permalinks_edit'] ) || ! is_post_type_viewable( get_post_type( $post_id ) ) ) {
             return;
         }
 


### PR DESCRIPTION
I'm on the engineering team for the AMP plugin. Someone [reported](https://wordpress.org/support/topic/article-redirected-to-home-page/) a compatibility issue in the support forum between Custom Permalinks and the AMP plugin.

When the AMP plugin's Developer Tools are active, each save to a post causes a loopback request to be made to the frontend to check the page for AMP validation issues, and the results are then stored in an `amp_validated_url` custom post type. This post type is not public. Nevertheless, when attempting to provide a custom permalink for a post, the same permalink also gets assigned to the `amp_validated_url` post type even though it is not public:

![image](https://user-images.githubusercontent.com/134745/91669061-c9e6ed00-eac6-11ea-83fc-9e64c9140e80.png)

The underlying cause for why this is happening is that the AMP plugin is creating a secondary post (`amp_validated_url`) in response to the `save_post` action of a public post being saved. The `Custom_Permalinks_Form::save_post()` method is acting on _both_ of those posts being saved, and since they are both being saved in the same request, the `$_REQUEST['custom_permalinks_edit']` variable is still defined and so it runs for both.

One quick way to fix this is to just check if the post being saved is public. That's what I've done here in this PR. I thought that this would also prevent the `custom_permalink` meta from also being set for `revision` post types, but for some reason it's not happening for it.

The better solution would probably to modify `Custom_Permalinks_Form::get_permalink_form()` to be passed the `$post_id` and that this would be output as the value of the `custom_permalinks_edit` hidden field. Then `Custom_Permalinks_Form::save_post()` could be modified as follows:

```diff
--- a/frontend/class-custom-permalinks-form.php
+++ b/frontend/class-custom-permalinks-form.php
@@ -138,7 +138,7 @@ class Custom_Permalinks_Form
      */
     public function save_post( $post_id )
     {
-        if ( ! isset( $_REQUEST['custom_permalinks_edit'] ) ) {
+        if ( ! isset( $_REQUEST['custom_permalinks_edit'] ) || (int) $_REQUEST['custom_permalinks_edit'] !== $post_id ) {
             return;
         }
```

This would guarantee that the `custom_permalink` post meta would only ever be updated for the post that was edited by the user. Nevertheless, I didn't do that in this PR because it was a larger change and it wasn't clear how the form for term permalinks would also need to be edited.

Steps to reproduce the issue with the AMP plugin:

1. Activate the AMP plugin
2. As an administrator user, create a post and save. (Admins have Developer Tools enabled by default.)
3. Provide a Custom Permalink for that post and save.
4. View the Custom Permalinks list and see there is a duplicate entry.