### PR TITLE
Update class-custom-permalinks-frontend.php

### DIFF
--- a/includes/class-custom-permalinks-frontend.php
+++ b/includes/class-custom-permalinks-frontend.php
@@ -201,7 +201,7 @@ class Custom_Permalinks_Frontend {
 		$cache_name = 'cp$_' . str_replace( '/', '-', $requested_url ) . '_#cp';
 		$posts      = wp_cache_get( $cache_name, 'custom_permalinks' );
 
-		if ( ! $posts ) {
+		if ( false === $posts ) {
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$posts = $wpdb->get_results(
 				$wpdb->prepare(
@@ -266,7 +266,7 @@ class Custom_Permalinks_Frontend {
 			return null;
 		}
 
-		if ( ! $matched_post ) {
+		if ( false === $matched_post ) {
 			$matched_post = array();
 
 			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery


### PR DESCRIPTION
Incorrect cache usage. According to this logic, if there is no data in the cache for the current URL, this is the normal state. But the plugin will still make the request again.

According to the documentation, you need to check the variable for "false" or use $found in the function.

https://developer.wordpress.org/reference/functions/wp_cache_get/