### PR TITLE
Remove url_to_postid filter before checking post id for redirect

### DIFF
--- a/includes/class-custom-permalinks-frontend.php
+++ b/includes/class-custom-permalinks-frontend.php
@@ -741,7 +741,10 @@ class Custom_Permalinks_Frontend {
 
 		$custom_permalink   = '';
 		$original_permalink = '';
-		$get_post_id        = url_to_postid( $this->request_uri );
+
+		remove_filter( 'url_to_postid', array( $this, 'postid_to_customized_permalink' ) );
+		$get_post_id = url_to_postid( $this->request_uri );
+		add_filter( 'url_to_postid', array( $this, 'postid_to_customized_permalink' ), 10, 1 );
 
 		// Redirect original post permalink.
 		if ( ! empty( $get_post_id ) ) {


### PR DESCRIPTION
It may fix the following support threads.
- https://wordpress.org/support/topic/polylang-redirect-issue-2/
- https://wordpress.org/support/topic/lost-password-link-conflict/
- https://wordpress.org/support/topic/custom-permalinks-is-conflicting-with-gravity-view-plugin/